### PR TITLE
記事編集ページ

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PrismaClient } from "@prisma/client";
+import { PostRequestBody } from "@/app/mypage/_types/PostRequestBody";
 
 const prisma = new PrismaClient();
 
@@ -61,6 +62,58 @@ export const DELETE = async (
         id: parseInt(id),
       },
     });
+
+    return NextResponse.json({ status: "OK", post: post }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error)
+      return NextResponse.json({ status: error.message }, { status: 400 });
+  }
+};
+
+//PUT
+export const PUT = async (
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) => {
+  const { id } = params;
+  const body: PostRequestBody = await request.json();
+  const { title, content, createdAt } = body;
+
+  try {
+    const post = await prisma.post.update({
+      where: {
+        id: parseInt(id),
+      },
+      data: {
+        title,
+        content,
+        createdAt,
+      },
+      include: {
+        postCategories: {
+          include: {
+            category: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+        postTags: {
+          include: {
+            tag: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    console.log(post);
 
     return NextResponse.json({ status: "OK", post: post }, { status: 200 });
   } catch (error) {

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -70,7 +70,7 @@ export const DELETE = async (
   }
 };
 
-//PUT
+// PUT
 export const PUT = async (
   request: NextRequest,
   { params }: { params: { id: string } }

--- a/src/app/mypage/_components/CalenderArea/index.tsx
+++ b/src/app/mypage/_components/CalenderArea/index.tsx
@@ -40,9 +40,6 @@ export const CalendarArea = () => {
 
       const data = await response.json();
 
-      console.log(data.studyTimes);
-      console.log(data.averageStudyTime);
-
       // 平均勉強時間をセット
       setAverageStudyTime(data.averageStudyTime);
 

--- a/src/app/mypage/_components/Item/_components/ItemMenu/index.tsx
+++ b/src/app/mypage/_components/Item/_components/ItemMenu/index.tsx
@@ -1,6 +1,6 @@
 'use-client';
 
-import React from 'react';
+import React, {useState} from 'react';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -8,18 +8,66 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
 import styles from './index.module.scss';
 import Link from 'next/link';
+import { useSupabaseSession } from '@/app/_hooks/useSupabaseSession';
+
 
 // 親からステートを受け取る
 interface ItemMenuProps {
-  anchorEl: HTMLElement | null;
-  open: boolean;
-  handleClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  handleClose: () => void;
-  handleDelete: () => void;
-  postId: number;
+  postId: number,
+  fetchPosts: () => Promise<void>;
 };
 
-export const ItemMenu: React.FC<ItemMenuProps> = ({ anchorEl, open, handleClick, handleClose, handleDelete, postId }) => {
+export const ItemMenu: React.FC<ItemMenuProps> = ({ postId, fetchPosts }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = !!anchorEl;
+  const { token } = useSupabaseSession();
+
+  // メニューを開く
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  // メニューを閉じる
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  // DELETE 記事を削除
+  const handleDelete = async () => {
+    if (!token || !postId) return;
+
+    const confirmed = confirm('削除した記事は復元できませんが、削除してよろしいですか。');
+    if (!confirmed) {
+      // メニューを閉じる
+      handleClose();
+      return;
+    };
+
+    console.log('削除');
+
+    try {
+      const response = await fetch(`api/posts/${postId}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: token,
+        },
+      });
+
+      if (!response.ok) {
+        console.error('記事削除失敗');
+      };
+
+      // ステートの更新
+      fetchPosts();
+      // メニューを閉じる
+      handleClose();
+
+    } catch (error) {
+      console.error('記事削除中に失敗', error);
+    };
+  };
+
 
   console.log(postId);
   

--- a/src/app/mypage/_components/Item/_components/ItemMenu/index.tsx
+++ b/src/app/mypage/_components/Item/_components/ItemMenu/index.tsx
@@ -7,6 +7,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
 import styles from './index.module.scss';
+import Link from 'next/link';
 
 // 親からステートを受け取る
 interface ItemMenuProps {
@@ -15,10 +16,13 @@ interface ItemMenuProps {
   handleClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   handleClose: () => void;
   handleDelete: () => void;
+  postId: number;
 };
 
-export const ItemMenu: React.FC<ItemMenuProps> = ({ anchorEl, open, handleClick, handleClose, handleDelete }) => {
+export const ItemMenu: React.FC<ItemMenuProps> = ({ anchorEl, open, handleClick, handleClose, handleDelete, postId }) => {
 
+  console.log(postId);
+  
   return (
     <div className={styles.editButton}>
       <Button
@@ -57,7 +61,11 @@ export const ItemMenu: React.FC<ItemMenuProps> = ({ anchorEl, open, handleClick,
           },
         }}
       >
-        <MenuItem onClick={handleClose}>編集</MenuItem>
+        <MenuItem onClick={handleClose}>
+          <Link href={`/mypage/posts/edit/${postId}`}>
+            編集
+          </Link>
+        </MenuItem>
         <MenuItem onClick={handleDelete}>削除</MenuItem>
       </Menu>
     </div>

--- a/src/app/mypage/_components/Item/index.tsx
+++ b/src/app/mypage/_components/Item/index.tsx
@@ -10,7 +10,7 @@ import { Slate, Editable, ReactEditor } from 'slate-react';
 import { HistoryEditor } from 'slate-history';
 import { RenderLeaf } from '@/app/mypage/_components/RenderLeaf';
 import { ItemMenu } from '@/app/mypage/_components/Item/_components/ItemMenu';
-import { useSupabaseSession } from '@/app/_hooks/useSupabaseSession';
+
 
 // 親からステートを受け取る
 interface ItemProps {
@@ -21,56 +21,6 @@ interface ItemProps {
 };
 
 export const Item = ({ posts, editor, fetchPosts }: ItemProps) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = !!anchorEl;
-  const { token } = useSupabaseSession();
-  const [postId, setPostId] = useState<number>();
-
-  // メニューを開く
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(e.currentTarget);
-  };
-
-  // メニューを閉じる
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  // DELETE 記事を削除
-  const handleDelete = async () => {
-    if (!token || !postId) return;
-
-    const confirmed = confirm('削除した記事は復元できませんが、削除してよろしいですか。');
-    if (!confirmed) {
-      // メニューを閉じる
-      handleClose();
-      return;
-    };
-
-    console.log('削除');
-
-    try {
-      const response = await fetch(`api/posts/${postId}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: token,
-        },
-      });
-
-      if (!response.ok) {
-        console.error('記事削除失敗');
-      };
-
-      // ステートの更新
-      fetchPosts();
-      // メニューを閉じる
-      handleClose();
-
-    } catch (error) {
-      console.error('記事削除中に失敗', error);
-    };
-  };
 
   return (
     <>
@@ -79,12 +29,8 @@ export const Item = ({ posts, editor, fetchPosts }: ItemProps) => {
           <li className={styles.postList}>
             <div className={styles.postListInner}>
               <ItemMenu
-                anchorEl={anchorEl}
-                open={open}
-                handleClick={handleClick}
-                handleClose={handleClose}
-                handleDelete={handleDelete}
                 postId={post.id}
+                fetchPosts={fetchPosts}
               />
             <Link href={`/mypage/posts/${post.id}`}>
               <div className={styles.top}>

--- a/src/app/mypage/_components/Item/index.tsx
+++ b/src/app/mypage/_components/Item/index.tsx
@@ -22,9 +22,9 @@ interface ItemProps {
 
 export const Item = ({ posts, editor, fetchPosts }: ItemProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
+  const open = !!anchorEl;
   const { token } = useSupabaseSession();
-  const [postId, setPostId] = useState<string | null>(null);
+  const [postId, setPostId] = useState<number>();
 
   // メニューを開く
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -78,16 +78,14 @@ export const Item = ({ posts, editor, fetchPosts }: ItemProps) => {
         <ul className={styles.post} key={post.id}>
           <li className={styles.postList}>
             <div className={styles.postListInner}>
-            <ItemMenu
-              anchorEl={anchorEl}
-              open={open}
-              handleClick={(e) => {
-                handleClick(e);
-                setPostId(post.id.toString());
-              }}
-              handleClose={handleClose}
-              handleDelete={handleDelete}
-            />
+              <ItemMenu
+                anchorEl={anchorEl}
+                open={open}
+                handleClick={handleClick}
+                handleClose={handleClose}
+                handleDelete={handleDelete}
+                postId={post.id}
+              />
             <Link href={`/mypage/posts/${post.id}`}>
               <div className={styles.top}>
                 <h2>{post.title}</h2>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -50,7 +50,6 @@ const Mypage = () => {
   // ステートが変更されるたびに更新する
   useEffect(() => {
     fetchPosts();
-    console.log(posts);
   }, [fetchPosts]);
 
   return (

--- a/src/app/mypage/posts/edit/[id]/page.tsx
+++ b/src/app/mypage/posts/edit/[id]/page.tsx
@@ -80,7 +80,10 @@ export default function Page() {
               title={title}
               setTitle={setTitle}
             />
-            {/* <DateInput/> */}
+            <DateInput
+              createdAt={createdAt}
+              setCreatedAt={setCreatedAt}
+            />
             <CategoryList
               selectCategories={selectCategories}
               setSelectCategories={setSelectCategories}

--- a/src/app/mypage/posts/edit/[id]/page.tsx
+++ b/src/app/mypage/posts/edit/[id]/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import {
+  FormEventHandler,
+  useEffect,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from 'react';
+import { useSupabaseSession } from '@/app/_hooks/useSupabaseSession';
+import { PostRequestBody } from '@/app/mypage/_types/PostRequestBody';
+import { Category } from '@/app/mypage/_types/Category';
+import { Tag } from '@/app/mypage/_types/Tag';
+import styles from '@/app/mypage/posts/new/_styles/PostNew.module.scss';
+import { Wrapper } from '@/app/_components/Wrapper';
+import { Button } from '@/app/_components/Button';
+import { Label } from '@/app/_components/Label';
+import { TextEditor } from '@/app/mypage/posts/new/_components/TextEditor';
+import { Title } from '../../new/_components/Title';
+import { DateInput } from '../../new/_components/DateInput';
+import { CategoryList } from '../../new/_components/CategoryList';
+import { TagList } from '../../new/_components/TagList';
+import { ReturnTop } from '../../new/_components/ReturnTop';
+import { CustomElement } from '../../new/_types/CustomElement';
+import { useParams } from 'next/navigation';
+
+const initialValue: CustomElement[] = [
+  {
+    type: 'paragraph',
+    children: [{ text: '初期設定のテキストテキスト' }],
+  },
+];
+
+export default function Page() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState<CustomElement[]>(initialValue);
+  const { id } = useParams();
+  const { token } = useSupabaseSession();
+  const [createdAt, setCreatedAt] = useState('');
+  const [selectCategories, setSelectCategories] = useState<Category[]>([]);
+  const [selectTags, setSelectTags] = useState<Tag[]>([]);
+
+  //GET 記事用
+  useEffect(() => {
+    if (!token) return
+    
+    const fetcher = async () => {
+      try {
+        const res = await fetch(`/api/posts/${id}`, {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: token,
+          },
+        });
+
+        const data = await res.json();
+
+        const { post } = data;
+        setTitle(post.title);
+        setCreatedAt(post.createdAt);
+        setSelectCategories(post.postCategories.map((cate: any) => cate.category));
+        setSelectTags(post.postTags.map((tag: any) => tag.tag));
+        setContent(JSON.parse(post.content));
+      }
+      catch (error) {
+        console.error(error);
+      };
+    };
+
+    fetcher();
+  }, [token, id]);
+  
+  return (
+    <>
+      <div className={styles.newPost}>
+        <Wrapper size={800}>
+          <ReturnTop/>
+          <form>
+            <Title
+              title={title}
+              setTitle={setTitle}
+            />
+            {/* <DateInput/> */}
+            <CategoryList
+              selectCategories={selectCategories}
+              setSelectCategories={setSelectCategories}
+            />
+            <TagList
+              selectTags={selectTags}
+              setSelectTags={setSelectTags}
+            />
+            <div>
+              <Label value='内容' />
+              <TextEditor
+                content={content}
+                setContent={setContent}
+              />
+            </div>
+            <div className={styles.btnArea}>
+              <Button
+                type='submit'
+                color='pink'
+                size='middle'
+              >
+                投稿
+              </Button>
+            </div>
+          </form>
+        </Wrapper>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
お疲れ様です！
質問事項が2点ありますので、以下にまとめています。
ご確認よろしくお願いします。

■質問事項
・src/app/mypage/_components/Itemで各記事をmapで出しています。
記事idを子コンポーネント（src/app/mypage/_components/Item/_components/ItemMenu）に渡して各記事の編集画面に遷移させたいです。
各記事のIDを子コンポーネントに渡すところが、できていません。

試したことは、以下2点です。
1)ItemMenuにpost.idを渡す
=>特定の記事IDしか取得されず、リンクがすべて一緒になってしまう。
2)子コンポーネントのLink内でmapする
=>当たり前なのですが、リンクは複数作れますが、ひとつのメニューにすべての記事リンクが生成されてしまう。

そのため、どのように実施するべきか、ヒントをいただきたいです。


・src/app/mypageの記事の三点リーダー「・・・」をクリックし、メニューを開くなどの動作をすると、取得される記事の内容が変わってしまいます。タイトルや日付は変わっていないので、slate.jsか何かしらのステートの渡し方が原因なのではと思っているのですが、その対処法を見つけられません。
以前、ご教授いただいた、slateにkeyを付与することは実施しています。こちらも対策などを教えていただきたいです。

お手数をおかけしますが、ご確認よろしくお願いします！